### PR TITLE
Remove line break which causes Makefile parse error

### DIFF
--- a/brandy/u-boot-2014.07/Makefile
+++ b/brandy/u-boot-2014.07/Makefile
@@ -1206,8 +1206,7 @@ tpl/u-boot-tpl.bin: tools prepare
 TAG_SUBDIRS := $(u-boot-dirs) include sunxi_spl
 
 FIND := find
-FINDFLAGS := -L
--R --c++-kinds=+p --fields=+iaS --extra=+q
+FINDFLAGS := -L -R --c++-kinds=+p --fields=+iaS --extra=+q
 tags ctags:
 		ctags -w -o ctags `$(FIND) $(FINDFLAGS) $(TAG_SUBDIRS) \
 						-name '*.[chS]' -print`


### PR DESCRIPTION
Correcting what appears to be a typo which ultimately causes the u-boot build to fail.